### PR TITLE
Could co.yixiang:yshop-mproot:2.3 drop off redundant dependencies?

### DIFF
--- a/yshop-mproot/pom.xml
+++ b/yshop-mproot/pom.xml
@@ -20,6 +20,16 @@
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-boot-starter</artifactId>
             <version>${mybatis-plus-boot-starter.version}</version>
+            <exclusions>
+                <exclusion>
+                   <artifactId>annotations</artifactId>
+                   <groupId>org.jetbrains</groupId>
+                </exclusion>
+                <exclusion>
+                   <artifactId>kotlin-stdlib-jdk7</artifactId>
+                   <groupId>org.jetbrains.kotlin</groupId>
+                </exclusion>
+           </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.github.pagehelper/pagehelper-spring-boot-starter -->
@@ -38,5 +48,108 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+               <groupId>eu.bitwalker</groupId>
+               <artifactId>UserAgentUtils</artifactId>
+               <version>1.21</version>
+               <scope>provided</scope>
+       </dependency>
+       <dependency>
+               <groupId>javax.inject</groupId>
+               <artifactId>javax.inject</artifactId>
+               <version>1</version>
+               <scope>provided</scope>
+       </dependency>
+       <dependency>
+               <groupId>org.projectlombok</groupId>
+               <artifactId>lombok</artifactId>
+               <version>1.18.24</version>
+               <scope>provided</scope>
+               <optional>true</optional>
+       </dependency>
+       <dependency>
+               <groupId>com.github.whvcse</groupId>
+               <artifactId>easy-captcha</artifactId>
+               <version>1.6.2</version>
+               <scope>provided</scope>
+       </dependency>
+       <dependency>
+               <groupId>javax.xml.bind</groupId>
+               <artifactId>jaxb-api</artifactId>
+               <version>2.3.0</version>
+               <scope>provided</scope>
+       </dependency>
+       <dependency>
+               <groupId>com.yomahub</groupId>
+               <artifactId>tlog-web-spring-boot-starter</artifactId>
+               <version>1.4.1</version>
+               <scope>compile</scope>
+               <exclusions>
+                 <exclusion>
+                   <artifactId>tlog-spring-boot-configuration</artifactId>
+                   <groupId>com.yomahub</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>tlog-okhttp</artifactId>
+                   <groupId>com.yomahub</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>tlog-task</artifactId>
+                   <groupId>com.yomahub</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>tlog-forest</artifactId>
+                   <groupId>com.yomahub</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>hutool-core</artifactId>
+                   <groupId>cn.hutool</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>dom4j</artifactId>
+                   <groupId>dom4j</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>commons-lang</artifactId>
+                   <groupId>commons-lang</groupId>
+                 </exclusion>
+               </exclusions>
+       </dependency>
+       <dependency>
+               <groupId>io.springfox</groupId>
+               <artifactId>springfox-swagger2</artifactId>
+               <version>3.0.0</version>
+               <scope>compile</scope>
+               <exclusions>
+                 <exclusion>
+                   <artifactId>swagger-annotations</artifactId>
+                   <groupId>io.swagger</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>swagger-models</artifactId>
+                   <groupId>io.swagger</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>byte-buddy</artifactId>
+                   <groupId>net.bytebuddy</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>classgraph</artifactId>
+                   <groupId>io.github.classgraph</groupId>
+                 </exclusion>
+               </exclusions>
+       </dependency>
+       <dependency>
+               <groupId>org.apache.poi</groupId>
+               <artifactId>poi-ooxml</artifactId>
+               <version>4.1.2</version>
+               <scope>compile</scope>
+               <exclusions>
+                 <exclusion>
+                   <artifactId>curvesapi</artifactId>
+                   <groupId>com.github.virtuald</groupId>
+                 </exclusion>
+               </exclusions>
+       </dependency>
     </dependencies>
 </project>

--- a/yshop-mproot/pom.xml
+++ b/yshop-mproot/pom.xml
@@ -49,107 +49,107 @@
             </exclusions>
         </dependency>
         <dependency>
-               <groupId>eu.bitwalker</groupId>
-               <artifactId>UserAgentUtils</artifactId>
-               <version>1.21</version>
-               <scope>provided</scope>
+            <groupId>eu.bitwalker</groupId>
+            <artifactId>UserAgentUtils</artifactId>
+            <version>1.21</version>
+            <scope>provided</scope>
        </dependency>
        <dependency>
-               <groupId>javax.inject</groupId>
-               <artifactId>javax.inject</artifactId>
-               <version>1</version>
-               <scope>provided</scope>
+           <groupId>javax.inject</groupId>
+           <artifactId>javax.inject</artifactId>
+           <version>1</version>
+           <scope>provided</scope>
        </dependency>
        <dependency>
-               <groupId>org.projectlombok</groupId>
-               <artifactId>lombok</artifactId>
-               <version>1.18.24</version>
-               <scope>provided</scope>
-               <optional>true</optional>
+           <groupId>org.projectlombok</groupId>
+           <artifactId>lombok</artifactId>
+           <version>1.18.24</version>
+           <scope>provided</scope>
+           <optional>true</optional>
        </dependency>
        <dependency>
-               <groupId>com.github.whvcse</groupId>
-               <artifactId>easy-captcha</artifactId>
-               <version>1.6.2</version>
-               <scope>provided</scope>
+           <groupId>com.github.whvcse</groupId>
+           <artifactId>easy-captcha</artifactId>
+           <version>1.6.2</version>
+           <scope>provided</scope>
        </dependency>
        <dependency>
-               <groupId>javax.xml.bind</groupId>
-               <artifactId>jaxb-api</artifactId>
-               <version>2.3.0</version>
-               <scope>provided</scope>
+           <groupId>javax.xml.bind</groupId>
+           <artifactId>jaxb-api</artifactId>
+           <version>2.3.0</version>
+           <scope>provided</scope>
        </dependency>
        <dependency>
-               <groupId>com.yomahub</groupId>
-               <artifactId>tlog-web-spring-boot-starter</artifactId>
-               <version>1.4.1</version>
-               <scope>compile</scope>
-               <exclusions>
-                 <exclusion>
+           <groupId>com.yomahub</groupId>
+           <artifactId>tlog-web-spring-boot-starter</artifactId>
+           <version>1.4.1</version>
+           <scope>compile</scope>
+           <exclusions>
+               <exclusion>
                    <artifactId>tlog-spring-boot-configuration</artifactId>
                    <groupId>com.yomahub</groupId>
-                 </exclusion>
-                 <exclusion>
+               </exclusion>
+               <exclusion>
                    <artifactId>tlog-okhttp</artifactId>
                    <groupId>com.yomahub</groupId>
-                 </exclusion>
-                 <exclusion>
+               </exclusion>
+               <exclusion>
                    <artifactId>tlog-task</artifactId>
                    <groupId>com.yomahub</groupId>
-                 </exclusion>
-                 <exclusion>
+               </exclusion>
+               <exclusion>
                    <artifactId>tlog-forest</artifactId>
                    <groupId>com.yomahub</groupId>
-                 </exclusion>
-                 <exclusion>
+               </exclusion>
+               <exclusion>
                    <artifactId>hutool-core</artifactId>
                    <groupId>cn.hutool</groupId>
-                 </exclusion>
-                 <exclusion>
+               </exclusion>
+               <exclusion>
                    <artifactId>dom4j</artifactId>
                    <groupId>dom4j</groupId>
-                 </exclusion>
-                 <exclusion>
+               </exclusion>
+               <exclusion>
                    <artifactId>commons-lang</artifactId>
                    <groupId>commons-lang</groupId>
-                 </exclusion>
-               </exclusions>
+               </exclusion>
+           </exclusions>
        </dependency>
        <dependency>
-               <groupId>io.springfox</groupId>
-               <artifactId>springfox-swagger2</artifactId>
-               <version>3.0.0</version>
-               <scope>compile</scope>
-               <exclusions>
-                 <exclusion>
+           <groupId>io.springfox</groupId>
+           <artifactId>springfox-swagger2</artifactId>
+           <version>3.0.0</version>
+           <scope>compile</scope>
+           <exclusions>
+               <exclusion>
                    <artifactId>swagger-annotations</artifactId>
                    <groupId>io.swagger</groupId>
-                 </exclusion>
-                 <exclusion>
+               </exclusion>
+               <exclusion>
                    <artifactId>swagger-models</artifactId>
                    <groupId>io.swagger</groupId>
-                 </exclusion>
-                 <exclusion>
+               </exclusion>
+               <exclusion>
                    <artifactId>byte-buddy</artifactId>
                    <groupId>net.bytebuddy</groupId>
-                 </exclusion>
-                 <exclusion>
+               </exclusion>
+               <exclusion>
                    <artifactId>classgraph</artifactId>
                    <groupId>io.github.classgraph</groupId>
-                 </exclusion>
-               </exclusions>
+               </exclusion>
+           </exclusions>
        </dependency>
        <dependency>
-               <groupId>org.apache.poi</groupId>
-               <artifactId>poi-ooxml</artifactId>
-               <version>4.1.2</version>
-               <scope>compile</scope>
-               <exclusions>
-                 <exclusion>
-                   <artifactId>curvesapi</artifactId>
-                   <groupId>com.github.virtuald</groupId>
-                 </exclusion>
-               </exclusions>
-       </dependency>
-    </dependencies>
+          <groupId>org.apache.poi</groupId>
+          <artifactId>poi-ooxml</artifactId>
+          <version>4.1.2</version>
+          <scope>compile</scope>
+          <exclusions>
+              <exclusion>
+                  <artifactId>curvesapi</artifactId>
+                  <groupId>com.github.virtuald</groupId>
+              </exclusion>
+          </exclusions>
+      </dependency>
+   </dependencies>
 </project>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/126549527/230759992-678cfb8c-1ca4-47ae-8324-d7d3a3c90e2a.png)
![image](https://user-images.githubusercontent.com/126549527/230760003-c4d64b22-8634-4601-9ad1-36b4fa3e78dc.png)
![image](https://user-images.githubusercontent.com/126549527/230760011-ef65963d-6502-49c5-b21c-686c9344df09.png)
![image](https://user-images.githubusercontent.com/126549527/230760024-79701bf7-b23b-44c8-9a2a-a3b24f49c483.png)
![image](https://user-images.githubusercontent.com/126549527/230760044-161697e1-b30c-416f-84db-d8b89256fa38.png)
![image](https://user-images.githubusercontent.com/126549527/230760054-d1c4eee2-3ab9-4bed-8fe9-949657d07cd1.png)
![image](https://user-images.githubusercontent.com/126549527/230760129-87c276a5-d317-4729-9bb7-e407e46d7fcc.png)
![image](https://user-images.githubusercontent.com/126549527/230760076-0c745c55-a00b-4f48-81a7-2f6ffad08b9f.png)
![image](https://user-images.githubusercontent.com/126549527/230760087-afb7df90-d57f-4c3c-b01f-0a291d0022c2.png)

Hi, I found that **_co.yixiang:yshop-mproot:2.3_**’s pom file introduced **_191_** dependencies. However, among them, **_17_** libraries (**_9%_** have not been used by your project), the redundant dependencies are listed below.

More seriously, **_2_** redundant dependencies contain security vulnerabilities (vulnerable libraries).

**_9_**  redundant libraries have not been maintained by developers for more than **_3_** years（outdated dependencies）.

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with security vulnerabilities and  outdated. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code.  

This PR **_co.yixiang:yshop-mproot:2.3_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant indirect dependencies:
        org.jetbrains:annotations:13.0:compile [17 KB]
        org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21:compile [23 KB]
#### Redundant direct dependencies inherited from parent pom:
        com.github.whvcse:easy-captcha:1.6.2:compile [339 KB]
        javax.xml.bind:jaxb-api:2.3.0:compile [122 KB]
        org.projectlombok:lombok:1.18.24:compile [1 MB]
        javax.inject:javax.inject:1:compile [2 KB]
        eu.bitwalker:UserAgentUtils:1.21:compile [45 KB]
#### Redundant indirect dependencies inherited from parent pom:
        com.yomahub:tlog-forest:1.4.1:compile [3 KB]
        com.github.virtuald:curvesapi:1.06:compile [109 KB]
        com.yomahub:tlog-task:1.4.1:compile [4 KB]
        net.bytebuddy:byte-buddy:1.12.20:compile [3 MB]
        com.yomahub:tlog-spring-boot-configuration:1.4.1:compile [9 KB]
        commons-lang:commons-lang:2.4:compile [255 KB]
        com.yomahub:tlog-okhttp:1.4.1:compile [3 KB]
        io.github.classgraph:classgraph:4.8.83:compile [492 KB]
        dom4j:dom4j:1.6.1:compile [306 KB]
        cn.hutool:hutool-core:5.7.16:compile [1 MB]

## Vulnerable libraries
cn.hutool:hutool-core:5.7.16(CVE-2022-4565)
dom4j:dom4j:1.6.1(CVE-2020-10683)

## Outdated dependencies
com.alibaba:QLExpress:3.2.0(**_1921_** days without maintenance)
commons-lang:commons-lang:2.4(**_5499_** days without maintenance)
javax.inject:javax.inject:1(**_4925_** days without maintenance)
com.github.virtuald:curvesapi:1.06(**_1855_** days without maintenance)
javax.xml.bind:jaxb-api:2.3.0(**_2078_** days without maintenance)
eu.bitwalker:UserAgentUtils:1.21(**_1901_** days without maintenance)
com.github.whvcse:easy-captcha:1.6.2(**_1321_** days without maintenance)
org.jetbrains:annotations:13.0(**_3400_** days without maintenance)
dom4j:dom4j:1.6.1(**_6267_** days without maintenance)
